### PR TITLE
Added full input and output to bucket name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-video",
-  "version": "2.3.9",
+  "version": "2.4.0",
   "description": "Plugin for Amplify to add support for live streaming. Made for Unicorn Trivia Workshop",
   "main": "index.js",
   "scripts": {

--- a/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
@@ -40,8 +40,8 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
     props.shared = nameDict;
     const uuid = Math.random().toString(36).substring(2, 6)
                 + Math.random().toString(36).substring(2, 6);
-    props.shared.bucketInput = `${nameDict.resourceName.toLowerCase()}-${projectDetails.localEnvInfo.envName}-i${uuid}`.slice(0, 63);
-    props.shared.bucketOutput = `${nameDict.resourceName.toLowerCase()}-${projectDetails.localEnvInfo.envName}-o${uuid}`.slice(0, 63);
+    props.shared.bucketInput = `${nameDict.resourceName.toLowerCase()}-${projectDetails.localEnvInfo.envName}-input-${uuid}`.slice(0, 63);
+    props.shared.bucketOutput = `${nameDict.resourceName.toLowerCase()}-${projectDetails.localEnvInfo.envName}-output-${uuid}`.slice(0, 63);
   }
 
   props.shared.bucket = projectMeta.providers.awscloudformation.DeploymentBucketName;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Feedback said we should use the full word input and output for our buckets instead of `i` & `o`.

Changed to using `input` and `output`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.