### PR TITLE
Support for File-Based Inputs for Live Streaming #38. Implemented MP4…

### DIFF
--- a/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/LambdaFunctions/psdemo-js-live-workflow_v0.4.0/lib/flagfish.js
+++ b/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/LambdaFunctions/psdemo-js-live-workflow_v0.4.0/lib/flagfish.js
@@ -239,11 +239,9 @@ class Flagfish extends mxStoreResponse(class { }) {
     if (this.ingestType === 'RTMP_PUSH') {
       payload.Destinations = ['p', 'b'].map(x => ({ StreamName: `${this.channelId}-${x}` }));
     }
-     /* MP4 file hack */
+     /* Set MediaLive input Source as the Url to MP4 file*/
     if (this.ingestType === 'MP4_FILE') {
-      payload.Sources = ['p', 'b'].map(x =>
-        ({ Url: `${this.mp4URL}` }));
-      //payload.Sources =  [{ Url: this.mp4URL }, {Url: this.mp4URL} }];
+      payload.Sources =  [{ Url: this.mp4URL }, {Url: this.mp4URL}];
     }
 
     const response = await this.flagfish.createInput(payload).promise();

--- a/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/LambdaFunctions/psdemo-js-live-workflow_v0.4.0/lib/flagfish.js
+++ b/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/LambdaFunctions/psdemo-js-live-workflow_v0.4.0/lib/flagfish.js
@@ -251,6 +251,7 @@ class Flagfish extends mxStoreResponse(class { }) {
       throw new Error(`response.Input missing ${missing.join(', ')}`);
     }
     if (this.ingestType === 'MP4_FILE') {
+      /* Just return when it is MP4_FILE */
       return response;
     }
     const { Destinations } = Input;

--- a/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/LambdaFunctions/psdemo-js-live-workflow_v0.4.0/lib/flagfish.js
+++ b/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/LambdaFunctions/psdemo-js-live-workflow_v0.4.0/lib/flagfish.js
@@ -23,6 +23,7 @@ const PS_PARAMS = [
   'PS_GOP_PER_SEGMENT',
   'PS_SEGMENT_PER_PLAYLIST',
   'PS_START_CHANNEL',
+  'PS_MP4_URL',
 ];
 
 const REQUIRED_ENV = [
@@ -114,6 +115,8 @@ class Flagfish extends mxStoreResponse(class { }) {
   get inputSecurityGroup() { return this.$event.ResourceProperties.PS_INPUT_SECURITY_GROUP; }
 
   get ingestType() { return this.$event.ResourceProperties.PS_INGEST_TYPE.toUpperCase(); }
+  
+  get mp4URL() { return this.$event.ResourceProperties.PS_MP4_URL; }
 
   get roleArn() { return this.$event.ResourceProperties.PS_ROLE_ARN; }
 
@@ -236,12 +239,22 @@ class Flagfish extends mxStoreResponse(class { }) {
     if (this.ingestType === 'RTMP_PUSH') {
       payload.Destinations = ['p', 'b'].map(x => ({ StreamName: `${this.channelId}-${x}` }));
     }
+     /* MP4 file hack */
+    if (this.ingestType === 'MP4_FILE') {
+      payload.Sources = ['p', 'b'].map(x =>
+        ({ Url: `${this.mp4URL}` }));
+      //payload.Sources =  [{ Url: this.mp4URL }, {Url: this.mp4URL} }];
+    }
 
     const response = await this.flagfish.createInput(payload).promise();
     const { Input } = response;
     const missing = ['Id', 'Arn', 'Name', 'Destinations'].filter(x => Input[x] === undefined);
     if (missing.length) {
       throw new Error(`response.Input missing ${missing.join(', ')}`);
+    }
+    if (this.ingestType === 'MP4_FILE') {
+      console.log(`MP4_FILE just return`);
+      return response;
     }
     const { Destinations } = Input;
     if (Destinations.length < 2) {
@@ -409,7 +422,15 @@ class Flagfish extends mxStoreResponse(class { }) {
       this.updateEncodingSettings(payload);
       this.configureDestinations(payload); // Add if statement for check if destination has mediapackage
       this.addMediaStoreOutputGroup(payload);
+      if (this.ingestType === "MP4_FILE") {
+        payload.InputAttachments[0].InputSettings.NetworkInputSettings = null;
+        payload.InputAttachments[0].InputSettings.SourceEndBehavior = "LOOP";
+        console.log("Calling createChannel");
+        console.log(JSON.stringify(payload));
+      }
       const response = await this.flagfish.createChannel(payload).promise(); // Should work
+      console.log("Returned from createChannel");
+      console.log(JSON.stringify(response));
       /* sanity check */
       const missing = ['Id', 'Arn', 'Name'].filter(x => response.Channel[x] === undefined);
       if (missing.length) {
@@ -492,8 +513,15 @@ class Flagfish extends mxStoreResponse(class { }) {
     this.storeResponseData('InputId', InputId);
     this.storeResponseData('InputName', InputName);
     this.storeResponseData('InputType', InputType);
-    this.storeResponseData('PrimaryIngestUrl', Destinations[0].Url);
-    this.storeResponseData('BackupIngestUrl', Destinations[1].Url);
+    if (this.ingestType === "MP4_FILE") {
+      console.log("MP4_FILE Input");
+      console.log(JSON.stringify(this.responseData, null, 2));
+      this.storeResponseData('PrimaryIngestUrl', this.mp4URL);
+      this.storeResponseData('BackupIngestUrl', this.mp4URL);
+    } else { 
+      this.storeResponseData('PrimaryIngestUrl', Destinations[0].Url);
+      this.storeResponseData('BackupIngestUrl', Destinations[1].Url);
+    }
 
     /* Next, create channel */
     response = await this.createChannel(InputId);

--- a/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/LambdaFunctions/psdemo-js-live-workflow_v0.4.0/lib/flagfish.js
+++ b/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/LambdaFunctions/psdemo-js-live-workflow_v0.4.0/lib/flagfish.js
@@ -251,7 +251,6 @@ class Flagfish extends mxStoreResponse(class { }) {
       throw new Error(`response.Input missing ${missing.join(', ')}`);
     }
     if (this.ingestType === 'MP4_FILE') {
-      console.log(`MP4_FILE just return`);
       return response;
     }
     const { Destinations } = Input;
@@ -423,12 +422,8 @@ class Flagfish extends mxStoreResponse(class { }) {
       if (this.ingestType === "MP4_FILE") {
         payload.InputAttachments[0].InputSettings.NetworkInputSettings = null;
         payload.InputAttachments[0].InputSettings.SourceEndBehavior = "LOOP";
-        console.log("Calling createChannel");
-        console.log(JSON.stringify(payload));
       }
       const response = await this.flagfish.createChannel(payload).promise(); // Should work
-      console.log("Returned from createChannel");
-      console.log(JSON.stringify(response));
       /* sanity check */
       const missing = ['Id', 'Arn', 'Name'].filter(x => response.Channel[x] === undefined);
       if (missing.length) {
@@ -512,8 +507,6 @@ class Flagfish extends mxStoreResponse(class { }) {
     this.storeResponseData('InputName', InputName);
     this.storeResponseData('InputType', InputType);
     if (this.ingestType === "MP4_FILE") {
-      console.log("MP4_FILE Input");
-      console.log(JSON.stringify(this.responseData, null, 2));
       this.storeResponseData('PrimaryIngestUrl', this.mp4URL);
       this.storeResponseData('BackupIngestUrl', this.mp4URL);
     } else { 

--- a/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/medialive-channel.template
+++ b/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/medialive-channel.template
@@ -27,7 +27,8 @@
             "pGopSizeInSec",
             "pGopPerSegment",
             "pSegmentPerPlaylist",
-            "pStartChannel"
+            "pStartChannel",
+            "pMp4URL"
           ]
         }
       ],
@@ -86,6 +87,9 @@
 
         "pStartChannel": {
           "default": "Auto-start"
+        },
+        "pMp4URL" : {
+          "default": "MP4 URL"
         }
       }
     }
@@ -153,6 +157,10 @@
 
         "PS_START_CHANNEL": {
           "Fn::Sub": "${pStartChannel}"
+        },
+
+        "PS_MP4_URL": {
+          "Fn::Sub": "${pMp4URL}"
         }
       }
     }
@@ -186,10 +194,16 @@
     "pIngestType": {
       "Type": "String",
       "Description": "medialive ingest type. Leave it as is",
-      "AllowedPattern" : "[A-Z_]*",
+      "AllowedPattern" : "[A-Z0-9_]*",
       "Default": "RTP_PUSH"
     },
 
+    "pMp4URL": {
+      "Type": "String",
+      "Description": "URL to MP4 File",
+      "Default": ""
+    },
+    
     "pEndpointUrls": {
       "Type": "String",
       "Description": "hls webdav ingest url(s) of your downstream packager, comma separator",

--- a/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/medialive.template
+++ b/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/medialive.template
@@ -29,7 +29,8 @@
             "pGopSizeInSec",
             "pGopPerSegment",
             "pSegmentPerPlaylist",
-            "pStartChannel"
+            "pStartChannel",
+            "pMp4URL"
           ]
         }
       ],
@@ -96,6 +97,9 @@
 
         "pStartChannel": {
           "default": "Start Channel"
+        },
+        "pMp4URL" : {
+          "default": "MP4 URL"
         }
       }
     }
@@ -215,6 +219,9 @@
 
           "pStartChannel": {
             "Ref": "pStartChannel"
+          },
+          "pMp4URL": {
+            "Ref": "pMp4URL"
           }
         }
       }
@@ -262,7 +269,7 @@
     "pIngestType": {
       "Type": "String",
       "Description": "medialive ingest type. Leave it as is",
-      "AllowedPattern" : "[A-Z_]*",
+      "AllowedPattern" : "[A-Z0-9_]*",
       "Default": "RTP_PUSH"
     },
 
@@ -323,6 +330,11 @@
       "Description": "starting the channel upon creation",
       "Default": "NO",
       "AllowedValues": [ "YES", "NO" ]
+    },
+    "pMp4URL": {
+      "Type": "String",
+      "Description": "URL to MP4 File",
+      "Default": ""
     }
   },
 

--- a/provider-utils/awscloudformation/cloudformation-templates/livestream-workflow.json.ejs
+++ b/provider-utils/awscloudformation/cloudformation-templates/livestream-workflow.json.ejs
@@ -30,7 +30,8 @@
             "pEncodingProfile",
             "pGopSizeInSec",
             "pGopPerSegment",
-            "pStartChannel"
+            "pStartChannel",
+            "pMp4URL"
           ]
         },
         {
@@ -93,6 +94,10 @@
 
         "pIngestType": {
           "default": "Ingest Type"
+        },
+        
+        "pMp4URL": {
+          "default": "URL to MP4 File"
         },
 
         "pEncodingProfile": {
@@ -253,6 +258,10 @@
 
           "pIngestType": {
             "Ref": "pIngestType"
+          },
+
+          "pMp4URL": {
+            "Ref": "pMp4URL"
           },
 
           "pEncodingProfile": {
@@ -466,8 +475,14 @@
     "pIngestType": {
       "Type": "String",
       "Description": "medialive ingest type",
-      "AllowedValues": [ "RTP_PUSH", "UDP_PUSH", "RTMP_PUSH" ],
+      "AllowedValues": [ "RTP_PUSH", "UDP_PUSH", "RTMP_PUSH", "MP4_FILE" ],
       "Default": "<%= props.mediaLive.ingestType %>"
+    },
+
+    "pMp4URL": {
+      "Type": "String",
+      "Description": "URL to MP4 File",
+      "Default": "<%= props.mediaLive.mp4URL %>"
     },
 
     "pEncodingProfile": {

--- a/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
@@ -1,7 +1,7 @@
 const inquirer = require('inquirer');
-const question = require('../../livestream-questions.json');
 const fs = require('fs-extra');
 const path = require('path');
+const question = require('../../livestream-questions.json');
 
 module.exports = {
   serviceQuestions,

--- a/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
@@ -19,7 +19,6 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   let cloudFrontAnswers = {};
   const props = {};
   let defaults = {};
- 
   defaults = JSON.parse(fs.readFileSync(`${defaultLocation}`));
   defaults.resourceName = 'mylivestream';
   try {

--- a/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
@@ -41,7 +41,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
       validate: amplify.inputValidation(inputs[0]),
       default: defaults.resourceName,
     }];
- 
+
   // prompt for advanced options
   const advanced = [
     {
@@ -107,7 +107,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
       default: defaults.mediaLive[inputs[7].key],
     },
   ];
- 
+
   const mp4Questions = [
     {
       type: inputs[17].type,
@@ -182,7 +182,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   } else {
     resource = await inquirer.prompt(nameProject);
   }
- 
+
   // main question control flow
   const answers = {};
   answers.bucket = projectMeta.providers.awscloudformation.DeploymentBucketName;
@@ -200,7 +200,6 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
     advancedAnswers.advancedChoice = true;
   }
 
-  //const mediaLiveAnswers = await inquirer.prompt(mediaLiveQuestions);
   mediaLiveAnswers = await inquirer.prompt(mediaLiveQuestions);
   if (mediaLiveAnswers.ingestType === 'MP4_FILE') {
     const mp4Answers = await inquirer.prompt(mp4Questions);

--- a/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
@@ -5,7 +5,7 @@ const question = require('../../livestream-questions.json');
 
 module.exports = {
   serviceQuestions,
-}
+};
 
 async function serviceQuestions(context, options, defaultValuesFilename, resourceName) {
   const { amplify } = context;
@@ -19,7 +19,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   let cloudFrontAnswers = {};
   const props = {};
   let defaults = {};
-  
+ 
   defaults = JSON.parse(fs.readFileSync(`${defaultLocation}`));
   defaults.resourceName = 'mylivestream';
   try {
@@ -41,7 +41,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
       validate: amplify.inputValidation(inputs[0]),
       default: defaults.resourceName,
     }];
-  
+ 
   // prompt for advanced options
   const advanced = [
     {
@@ -49,8 +49,8 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
       name: inputs[16].key,
       message: inputs[16].question,
       default: defaults.advanced[inputs[16].key],
-    }
-  ]
+    },
+  ];
 
   // advanced options (currently only segmentation settings)
   const advancedQuestions = [
@@ -75,7 +75,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
       validate: amplify.inputValidation(inputs[3]),
       default: defaults.advanced[inputs[3].key],
     },
-  ]
+  ];
 
   const mediaLiveQuestions = [
     {
@@ -107,14 +107,14 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
       default: defaults.mediaLive[inputs[7].key],
     },
   ];
-  
+ 
   const mp4Questions = [
     {
       type: inputs[17].type,
       name: inputs[17].key,
       message: inputs[17].question,
       default: defaults.advanced[inputs[17].key],
-    }
+    },
   ];
 
   const mediaPackageQuestions = [
@@ -182,7 +182,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   } else {
     resource = await inquirer.prompt(nameProject);
   }
-  
+ 
   // main question control flow
   const answers = {};
   answers.bucket = projectMeta.providers.awscloudformation.DeploymentBucketName;
@@ -190,7 +190,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   answers.resourceName = resource.name;
 
   const advancedEnable = await inquirer.prompt(advanced);
-  if (advancedEnable.advancedChoice == false) {
+  if (advancedEnable.advancedChoice === false) {
     advancedAnswers.gopSize = '1';
     advancedAnswers.gopPerSegment = '2';
     advancedAnswers.segsPerPlist = '3';

--- a/provider-utils/livestream-questions.json
+++ b/provider-utils/livestream-questions.json
@@ -281,7 +281,7 @@
                 "validation": {
                     "operator": "regex",
                     "value": "^[a-z0-9_:\\\/]+$",
-                    "onErrorMsg": "mp4URL can only be a valid url"
+                    "onErrorMsg": "Error the provided URL is not valid"
                 },
                 "required": true
             }

--- a/provider-utils/livestream-questions.json
+++ b/provider-utils/livestream-questions.json
@@ -67,6 +67,10 @@
                     {
                         "name": "UDP_PUSH",
                         "value": "UDP_PUSH"
+                    },
+                    {
+                        "name": "MP4_FILE",
+                        "value": "MP4_FILE"
                     }
                 ],
                 "required": true
@@ -270,7 +274,17 @@
               "type": "confirm",
               "question": "Do you want to modify any advanced video encoding parameters?",
               "required": true
-          }
+            },
+            {
+                "key": "mp4URL",
+                "question": "Provide URL to the MP4 file: ",
+                "validation": {
+                    "operator": "regex",
+                    "value": "^[a-z0-9_:\\\/]+$",
+                    "onErrorMsg": "mp4URL can only be a valid url"
+                },
+                "required": true
+            }
         ],
         "cfnFilename": "elemental-cloudformation-template.json.ejs",
         "provider": "awscloudformation"


### PR DESCRIPTION
…_FILE option for livestream

*Issue #, if available: #38 

*Description of changes:*
Implemented MP4_FILE option for livestream. This workflow now creates a MediaLive input with the mp4 file URL input parameter. The input is attached to a newly created MediaLive channel and corresponding MediaPackage destination. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.