### PR TITLE
Bumped node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-category-video",
-  "version": "2.4.1",
+  "version": "2.5.1",
   "description": "Plugin for Amplify to add support for live streaming. Made for Unicorn Trivia Workshop",
   "main": "index.js",
   "scripts": {

--- a/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/lambda.template
+++ b/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/lambda.template
@@ -62,7 +62,7 @@
             { "Ref": "AWS::NoValue" }
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "MemorySize": { "Ref": "pMemorySize" },
         "Timeout": { "Ref": "pTimeout" },
         "Handler": { "Ref": "pLambdaHandler" },


### PR DESCRIPTION
*Issue #, if available:* Bumps node version

*Description of changes:* Removes Node 8.10 from Amplify video


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.