### PR TITLE
Removed node8 tests as we no longer support node8

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Remove Node 8 tests due to us no longer supporting node 8


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.