### PR TITLE
Fix OBS setup which create wrong stream URL

### DIFF
--- a/provider-utils/awscloudformation/utils/livestream-obs.js
+++ b/provider-utils/awscloudformation/utils/livestream-obs.js
@@ -86,11 +86,10 @@ function generateServiceIVS(directory, projectOutput) {
 
 function generateServiceLive(directory, primaryURL) {
   const primaryKey = primaryURL.split('/');
-  const formatedPrimaryURL = primaryURL.replace('rtmp://', '');
   const setup = {
     settings: {
       key: primaryKey[3],
-      server: `rtmps://${formatedPrimaryURL}`,
+      server: primaryURL,
     },
     type: 'rtmp_custom',
   };

--- a/provider-utils/awscloudformation/utils/livestream-obs.js
+++ b/provider-utils/awscloudformation/utils/livestream-obs.js
@@ -94,7 +94,6 @@ function generateServiceLive(directory, primaryURL) {
     },
     type: 'rtmp_custom',
   };
-  console.log(setup);
   const json = JSON.stringify(setup);
   fs.writeFileSync(`${directory}service.json`, json);
 }

--- a/provider-utils/awscloudformation/utils/livestream-obs.js
+++ b/provider-utils/awscloudformation/utils/livestream-obs.js
@@ -86,13 +86,15 @@ function generateServiceIVS(directory, projectOutput) {
 
 function generateServiceLive(directory, primaryURL) {
   const primaryKey = primaryURL.split('/');
+  const formatedPrimaryURL = primaryURL.replace('rtmp://', '');
   const setup = {
     settings: {
       key: primaryKey[3],
-      server: `rtmps://${primaryURL}`,
+      server: `rtmps://${formatedPrimaryURL}`,
     },
     type: 'rtmp_custom',
   };
+  console.log(setup);
   const json = JSON.stringify(setup);
   fs.writeFileSync(`${directory}service.json`, json);
 }


### PR DESCRIPTION
*Fix issue #155*

Description of changes:
Remove the extra protocol in the URI when using Element Livestream.

`rtmps://rtmp://IP_ADDRESS:1935/livestream-dev-p`

to

`rtmp://IP_ADDRESS:1935/livestream-dev-p`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.