### PR TITLE
Adding support for new CF Signed url

### DIFF
--- a/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/CFDistribution.template.ejs
+++ b/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/CFDistribution.template.ejs
@@ -1,15 +1,20 @@
 Description: CloudFront Distribution for output bucket
 
 Parameters:
-  pBucketName:
+  pBucketUrl:
     Type: String
     Description: ProjectName
-    AllowedPattern: "[a-zA-Z][a-zA-Z0-9-_]*"
     Default: DefaultName
   pOriginAccessIdentity:
     Type: String
     Description: Policy for bucket
     Default: NA
+  <% if (props.contentDeliveryNetwork.signedKey) { %>
+  pProjectName:
+    Type: String
+    Description: Name for public key
+    Default: PublicKey
+  <% } %>
 
 Resources:
   rCloudFrontDist:
@@ -26,19 +31,39 @@ Resources:
           TargetOriginId: "vodS3Origin"
           ViewerProtocolPolicy: "allow-all"
           <% if (props.contentDeliveryNetwork.signedKey) { %>
-          TrustedSigners:
-            - self
+          TrustedKeyGroups:
+            - !Ref rCloudFrontKeyGroup
           <% } %>
         Origins: 
           - 
-            DomainName: !Sub "${pBucketName}.s3.amazonaws.com"
+            DomainName: !Ref pBucketUrl
             Id: vodS3Origin
             S3OriginConfig:
               OriginAccessIdentity: !Sub "origin-access-identity/cloudfront/${pOriginAccessIdentity}"
         Enabled: 'true'
         PriceClass: PriceClass_All
-
+  <% if (props.contentDeliveryNetwork.signedKey) { %>
+  <%= props.contentDeliveryNetwork.rPublicName %>:
+    Type: AWS::CloudFront::PublicKey
+    Properties:
+      PublicKeyConfig:
+        CallerReference: <%= props.contentDeliveryNetwork.publicKeyName %>
+        Name: <%= props.contentDeliveryNetwork.publicKeyName %>
+        EncodedKey: "<%= props.contentDeliveryNetwork.publicKey %>"
+  rCloudFrontKeyGroup:
+    Type: AWS::CloudFront::KeyGroup
+    Properties:
+      KeyGroupConfig:
+        Name: !Sub "${pProjectName}-KeyGroup"
+        Items:
+            - !Ref <%= props.contentDeliveryNetwork.rPublicName %>
+  <% } %>
 Outputs:
+<% if (props.contentDeliveryNetwork.signedKey) { %>
+  oPemId:
+    Value: !Ref <%= props.contentDeliveryNetwork.rPublicName %>
+    Description: Pem Key Id
+<% } %>
   oCFDomain:
     Value: !GetAtt rCloudFrontDist.DomainName
     Description: Domain for our videos

--- a/provider-utils/awscloudformation/cloudformation-templates/vod-workflow-template.yaml.ejs
+++ b/provider-utils/awscloudformation/cloudformation-templates/vod-workflow-template.yaml.ejs
@@ -103,15 +103,23 @@ Resources:
     Properties:
       TemplateURL: !Sub "https://s3.amazonaws.com/${pS3}/${pSourceFolder}/CFDistribution.template"
       Parameters:
-          pBucketName: !Ref pS3OutputName
+          pBucketUrl: !GetAtt rS3OutputBucket.Outputs.oOutputUrl
           pOriginAccessIdentity: !GetAtt rS3OutputBucket.Outputs.oOriginAccessIdentity
-<% if (props.contentDeliveryNetwork.signedKey) { %>
+  <% if (props.contentDeliveryNetwork.signedKey) { %>
+          pProjectName:
+            !If
+            - HasEnvironmentParameter
+            - !Join
+              - '-'
+              - - !Ref pProjectName
+                - !Ref env
+            - !Ref pProjectName
   rCloudfrontTokenGenerator:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub "https://s3.amazonaws.com/${pS3}/${pSourceFolder}/CFTokenGen.template"
       Parameters:
-          pPemID: <%= props.contentDeliveryNetwork.pemID %>
+          pPemID: !GetAtt rCloudfrontDistribution.Outputs.oPemId
           pSecretPem: <%= props.contentDeliveryNetwork.secretPem %>
           pSecretPemArn: <%= props.contentDeliveryNetwork.secretPemArn %>
           pDomainName: !GetAtt rCloudfrontDistribution.Outputs.oCFDomain
@@ -129,7 +137,7 @@ Resources:
               - '-'
               - - !Ref pProjectName
                 - 'tokenGen'
-<% } %>
+  <% } %>
 <% } %>
   rMediaConvertTemplate:
     Type: AWS::CloudFormation::Stack

--- a/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
@@ -2,6 +2,7 @@ const inquirer = require('inquirer');
 const fs = require('fs-extra');
 const path = require('path');
 const ejs = require('ejs');
+const { generateKeyPairSync } = require('crypto');
 const question = require('../../vod-questions.json');
 const { getAWSConfig } = require('../utils/get-aws');
 const { generateIAMAdmin, generateIAMAdminPolicy } = require('./vod-roles');
@@ -18,6 +19,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   const defaults = JSON.parse(fs.readFileSync(`${defaultLocation}`));
   const targetDir = amplify.pathManager.getBackendDirPath();
   const props = {};
+  let oldValues = {};
   let nameDict = {};
   let aws;
 
@@ -35,7 +37,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
     nameDict.resourceName = resourceName;
     props.shared = nameDict;
     try {
-      const oldValues = JSON.parse(fs.readFileSync(`${targetDir}/video/${resourceName}/props.json`));
+      oldValues = JSON.parse(fs.readFileSync(`${targetDir}/video/${resourceName}/props.json`));
       Object.assign(defaults, oldValues);
     } catch (err) {
       // Do nothing
@@ -147,7 +149,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   const cdnResponse = await inquirer.prompt(cdnEnable);
 
   if (cdnResponse.enableCDN === true) {
-    const contentDeliveryNetwork = await createCDN(context, props, options, aws);
+    const contentDeliveryNetwork = await createCDN(context, props, options, aws, oldValues);
     props.contentDeliveryNetwork = contentDeliveryNetwork;
   }
 
@@ -201,62 +203,77 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   return props;
 }
 
-async function createCDN(context, props, options, aws) {
+async function createCDN(context, props, options, aws, oldValues) {
   const { inputs } = question.video;
   const { amplify } = context;
   const projectDetails = amplify.getProjectDetails();
   const cdnConfigDetails = {};
-  const validateFile = (input) => {
-    if (fs.existsSync(input)) {
-      return true;
+
+  if (oldValues.contentDeliveryNetwork.signedKey) {
+    const signedURLQuestion = [{
+      type: inputs[7].type,
+      name: inputs[7].key,
+      message: inputs[7].question,
+      choices: inputs[7].options,
+      default: 'leave',
+    }];
+    const signedURLResponse = await inquirer.prompt(signedURLQuestion);
+    if (signedURLResponse.modifySignedUrl === 'leave') {
+      return oldValues.contentDeliveryNetwork;
     }
-    return 'File does not exist';
-  };
-  const signedURLQuestion = [{
-    type: inputs[9].type,
-    name: inputs[9].key,
-    message: inputs[9].question,
-    validate: amplify.inputValidation(inputs[9]),
-    default: true,
-  }];
+    if (signedURLResponse.modifySignedUrl === 'remove') {
+      cdnConfigDetails.signedKey = false;
+    } else {
+      cdnConfigDetails.signedKey = true;
+    }
+  } else {
+    const signedURLQuestion = [{
+      type: inputs[9].type,
+      name: inputs[9].key,
+      message: inputs[9].question,
+      validate: amplify.inputValidation(inputs[9]),
+      default: true,
+    }];
+    const signedURLResponse = await inquirer.prompt(signedURLQuestion);
 
-  const signedURLResponse = await inquirer.prompt(signedURLQuestion);
+    cdnConfigDetails.signedKey = signedURLResponse.signedKey;
+  }
 
-  cdnConfigDetails.signedKey = signedURLResponse.signedKey;
-
-  if (signedURLResponse.signedKey) {
-    const tokenGenQuestions = [
-      {
-        type: inputs[7].type,
-        name: inputs[7].key,
-        message: inputs[7].question,
-        validate: validateFile,
-        default: '',
+  if (cdnConfigDetails.signedKey) {
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: {
+        type: 'spki',
+        format: 'pem',
       },
-      {
-        type: inputs[8].type,
-        name: inputs[8].key,
-        message: inputs[8].question,
-        validate: amplify.inputValidation(inputs[8]),
-        default: '',
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem',
       },
-    ];
+    });
 
-    const tokenGenResponse = await inquirer.prompt(tokenGenQuestions);
-
-    const pemKey = fs.readFileSync(tokenGenResponse.pemKeyLocation);
     if (!aws) {
       const provider = getAWSConfig(context, options);
       aws = await provider.getConfiguredAWSClient(context);
     }
+    const uuid = Math.random().toString(36).substring(2, 6)
+                + Math.random().toString(36).substring(2, 6);
+    const secretName = `${props.shared.resourceName}-${projectDetails.localEnvInfo.envName}-pem-${uuid}`.slice(0, 63);
+    const rPublicName = `rCloudFrontPublicKey${uuid}`.slice(0, 63);
+    const publicKeyName = `${props.shared.resourceName}-${projectDetails.localEnvInfo.envName}-publickey-${uuid}`.slice(0, 63);
     const smClient = new aws.SecretsManager({ apiVersion: '2017-10-17' });
     const createSecretParams = {
-      Name: `${props.shared.resourceName}-pem`,
-      SecretBinary: pemKey,
+      Name: secretName,
+      SecretBinary: privateKey,
     };
     const secretCreate = await smClient.createSecret(createSecretParams).promise();
-
-    cdnConfigDetails.pemID = tokenGenResponse.pemKeyID;
+    cdnConfigDetails.publicKey = publicKey.replace(/\n/g, '\\n');
+    // Note: This is NOT best pratices for CloudFormation but their is
+    // a bug with CloudFront's new Key Groups that doesn't allow
+    // us to rotate them so we are temporary doing a hard rotate
+    // Ref: ISSUE - TBD
+    cdnConfigDetails.rPublicName = rPublicName;
+    cdnConfigDetails.publicKeyName = publicKeyName;
     cdnConfigDetails.secretPem = secretCreate.Name;
     cdnConfigDetails.secretPemArn = secretCreate.ARN;
     cdnConfigDetails.functionName = (projectDetails.localEnvInfo.envName)

--- a/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
@@ -209,7 +209,7 @@ async function createCDN(context, props, options, aws, oldValues) {
   const projectDetails = amplify.getProjectDetails();
   const cdnConfigDetails = {};
 
-  if (oldValues.contentDeliveryNetwork.signedKey) {
+  if (oldValues.contentDeliveryNetwork && oldValues.contentDeliveryNetwork.signedKey) {
     const signedURLQuestion = [{
       type: inputs[7].type,
       name: inputs[7].key,

--- a/provider-utils/vod-questions.json
+++ b/provider-utils/vod-questions.json
@@ -52,13 +52,26 @@
                 "required":true
             }, 
             {
-                "key": "pemKeyLocation",
-                "type":"input",
-                "question": "Provide the location to the pem key you want CloudFront you want to sign urls with:",
-                "required": true
+                "key": "modifySignedUrl",
+                "type":"list",
+                "question": "We detected you have signed urls configured. Would you like to:",
+                "options": [
+                    {
+                        "name": "Leave as configured",
+                        "value": "leave"
+                    },
+                    {
+                        "name": "Rotate the keys for the signed urls",
+                        "value": "rotate"
+                    },
+                    {
+                        "name": "Remove signed urls",
+                        "value": "remove"
+                    }
+                ]
             },
             {
-                "key": "pemKeyID",
+                "key": "pemKeyID-DEADDONOTUSE",
                 "type":"input",
                 "question": "What is the CloudFront Key Pair Access Key ID associated with the pem key?",
                 "required": true


### PR DESCRIPTION
*Issue #, if available:* Fixes #181

*Description of changes:* 
- Adds the ability to rotate CF Keys
- Removes support for Root keys in favor of the new CloudFront public keys (migration path is easy and will happen automatically when running amplify video update and selecting rotate keys)
- Fixes bug when running update and secret keys will collide.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.