### PR TITLE
Support multiple backends & minor fixes

### DIFF
--- a/commands/video/build.js
+++ b/commands/video/build.js
@@ -8,9 +8,12 @@ module.exports = {
   name: subcommand,
   run: async (context) => {
     const { amplify } = context;
-    const targetDir = amplify.pathManager.getBackendDirPath();
     const amplifyMeta = amplify.getProjectMeta();
+    const targetDir = amplify.pathManager.getBackendDirPath();
     const projectDetails = context.amplify.getProjectDetails();
+    const newEnvName = projectDetails.localEnvInfo.envName;
+    const resourceFilesBaseDir = `${targetDir}/video/${shared.resourceName}/`;
+    const resourceFilesList = fs.readdirSync(resourceFilesBaseDir);
 
     if (!(category in amplifyMeta) || Object.keys(amplifyMeta[category]).length === 0) {
       context.print.error(`You have no ${category} projects.`);
@@ -34,6 +37,48 @@ module.exports = {
     if (!buildTemplates) {
       context.print.error('No builder is configured for this provider');
       return;
+    }
+
+    // Check if env-specific props file already exists
+    const hasOwnEnvProps = resourceFilesList.includes(`${newEnvName}-props.json`);
+
+    // Check if ANY props file exist for a different env in this project  || returns array
+    const hasAnyEnvProps = resourceFilesList.find(fileName => fileName.includes('-props.json'));
+
+    // If this env doesn't have its own props AND there is an existing amplify-video resource
+    if (!hasOwnEnvProps && hasAnyEnvProps) {
+      // take the first props file you find and copy that!
+      const propsFilenameToCopy = resourceFilesList.filter(propsFileName => propsFileName.includes('-props.json'))[0];
+
+      // extract substring for the existing env's name we're going to copy over
+      const envNameToReplace = propsFilenameToCopy.substr(0, propsFilenameToCopy.indexOf('-'));
+
+      // read JSON from the existing env's props file
+      const existingPropsToMutate = JSON.parse(fs.readFileSync(`${resourceFilesBaseDir}/${propsFilenameToCopy}`));
+
+      const searchAndReplaceProps = () => {
+        const newPropsObj = {};
+        // eslint-disable-next-line no-restricted-syntax
+        for (const [key, value] of Object.entries(existingPropsToMutate.contentDeliveryNetwork)) {
+          // look for any string values that contain existing env's name
+          if (typeof value === 'string' && value.includes(`${envNameToReplace}`)) {
+            // replace with new env name
+            const newValue = value.replace(new RegExp(envNameToReplace, 'g'), `${newEnvName}`);
+            newPropsObj[key] = newValue;
+          } else {
+            // copy existing values that do not match replacement conditions aka "generic props"
+            newPropsObj[key] = value;
+          }
+        }
+        return newPropsObj;
+      };
+
+      // merge new props and existing generic props
+      const newPropsToSave = Object.assign(
+        existingPropsToMutate, { contentDeliveryNetwork: searchAndReplaceProps() },
+      );
+
+      fs.writeFileSync(`${resourceFilesBaseDir}/${newEnvName}-props.json`, JSON.stringify(newPropsToSave, null, 4));
     }
 
     const props = JSON.parse(fs.readFileSync(`${targetDir}/video/${shared.resourceName}/${projectDetails.localEnvInfo.envName}-props.json`));

--- a/commands/video/build.js
+++ b/commands/video/build.js
@@ -10,6 +10,7 @@ module.exports = {
     const { amplify } = context;
     const targetDir = amplify.pathManager.getBackendDirPath();
     const amplifyMeta = amplify.getProjectMeta();
+    const projectDetails = context.amplify.getProjectDetails();
 
     if (!(category in amplifyMeta) || Object.keys(amplifyMeta[category]).length === 0) {
       context.print.error(`You have no ${category} projects.`);
@@ -35,7 +36,7 @@ module.exports = {
       return;
     }
 
-    const props = JSON.parse(fs.readFileSync(`${targetDir}/video/${shared.resourceName}/props.json`));
+    const props = JSON.parse(fs.readFileSync(`${targetDir}/video/${shared.resourceName}/${projectDetails.localEnvInfo.envName}-props.json`));
 
     return buildTemplates(context, props);
   },

--- a/provider-utils/awscloudformation/cloudformation-templates/ivs-helpers/IVS-Channel.template
+++ b/provider-utils/awscloudformation/cloudformation-templates/ivs-helpers/IVS-Channel.template
@@ -36,3 +36,4 @@ Resources:
       name: !Ref pProjectName
       type: !Ref pQuality
       latencyMode: !Ref pLatencyMode
+      tags: {"amplify-video" : "amplify-video"}

--- a/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/cloudfront-distribution.template
+++ b/provider-utils/awscloudformation/cloudformation-templates/livestream-helpers/cloudfront-distribution.template
@@ -166,6 +166,10 @@
     "rDistribution" : {
       "Type": "AWS::CloudFront::Distribution",
       "Properties": {
+        "Tags" : [{
+          "Key" : "amplify-video",
+          "Value" : "amplify-video"
+        }],
         "DistributionConfig": {
           "Origins": [
             {

--- a/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/CFDistribution.template.ejs
+++ b/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/CFDistribution.template.ejs
@@ -20,6 +20,9 @@ Resources:
   rCloudFrontDist:
     Type: AWS::CloudFront::Distribution
     Properties:
+      Tags:
+      - Key: amplify-video
+        Value: amplify-video
       DistributionConfig:
         DefaultCacheBehavior:
           ForwardedValues:
@@ -40,8 +43,8 @@ Resources:
           TrustedKeyGroups:
             - !Ref rCloudFrontKeyGroup
           <% } %>
-        Origins: 
-          - 
+        Origins:
+          -
             DomainName: !Ref pBucketUrl
             Id: vodS3Origin
             S3OriginConfig:

--- a/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/LambdaFunctions/CloudFrontTokenGen/index.js
+++ b/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/LambdaFunctions/CloudFrontTokenGen/index.js
@@ -4,10 +4,10 @@ const aws = require('aws-sdk');
 var globalPem;
 /* eslint-enable */
 
-exports.handler = async (event) => {
+async function handler(event) {
   const response = await signPath(event.source.id);
   return response;
-};
+}
 
 async function sign(pathURL) {
   const epoch = Math.floor(new Date(new Date().getTime() + (3600 * 1000)).getTime() / 1000);
@@ -45,4 +45,5 @@ async function signPath(id) {
 
 module.exports = {
   signPath,
+  handler,
 };

--- a/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/LambdaFunctions/InputLambda/index.js
+++ b/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/LambdaFunctions/InputLambda/index.js
@@ -64,6 +64,7 @@ async function createJob(eventObject) {
     UserMetadata: {},
     Role: process.env.MC_ROLE,
     Settings: jobSettings,
+    Tags: { 'amplify-video': 'amplify-video' },
   };
   await mcClient.createJob(jobParams).promise();
 }

--- a/provider-utils/awscloudformation/index.js
+++ b/provider-utils/awscloudformation/index.js
@@ -8,6 +8,7 @@ let serviceMetadata;
 async function addResource(context, service, options) {
   serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const targetDir = context.amplify.pathManager.getBackendDirPath();
+  const projectDetails = context.amplify.getProjectDetails();
   const { serviceWalkthroughFilename, defaultValuesFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
   const { serviceQuestions } = require(serviceWalkthroughSrc);
@@ -23,13 +24,14 @@ async function addResource(context, service, options) {
   if (result.parameters !== undefined) {
     await fs.writeFileSync(`${targetDir}/video/${result.shared.resourceName}/parameters.json`, JSON.stringify(result.parameters, null, 4));
   }
-  await fs.writeFileSync(`${targetDir}/video/${result.shared.resourceName}/props.json`, JSON.stringify(result, null, 4));
+  await fs.writeFileSync(`${targetDir}/video/${result.shared.resourceName}/${projectDetails.localEnvInfo.envName}-props.json`, JSON.stringify(result, null, 4));
   await buildTemplates(context, result);
 }
 
 async function updateResource(context, service, options, resourceName) {
   serviceMetadata = context.amplify.readJsonFile(`${__dirname}/../supported-services.json`)[service];
   const targetDir = context.amplify.pathManager.getBackendDirPath();
+  const projectDetails = context.amplify.getProjectDetails();
   const { serviceWalkthroughFilename, defaultValuesFilename } = serviceMetadata;
   const serviceWalkthroughSrc = `${__dirname}/service-walkthroughs/${serviceWalkthroughFilename}`;
   const { serviceQuestions } = require(serviceWalkthroughSrc);
@@ -37,7 +39,7 @@ async function updateResource(context, service, options, resourceName) {
   if (result.parameters !== undefined) {
     await fs.writeFileSync(`${targetDir}/video/${result.shared.resourceName}/parameters.json`, JSON.stringify(result.parameters, null, 4));
   }
-  await fs.writeFileSync(`${targetDir}/video/${result.shared.resourceName}/props.json`, JSON.stringify(result, null, 4));
+  await fs.writeFileSync(`${targetDir}/video/${result.shared.resourceName}/${projectDetails.localEnvInfo.envName}-props.json`, JSON.stringify(result, null, 4));
   await buildTemplates(context, result);
   context.print.success(`Successfully updated ${result.shared.resourceName}`);
 }

--- a/provider-utils/awscloudformation/schemas/schema.graphql.ejs
+++ b/provider-utils/awscloudformation/schemas/schema.graphql.ejs
@@ -42,7 +42,7 @@ type videoObject @model
 )
 {
   id:ID!
-<% if (contentDeliveryNetwork.signedKey) { %>
-  token: String @function(name: "<%= contentDeliveryNetwork.functionName %>")
+<% if (contentDeliveryNetwork.signedKey) { -%>
+  token: String @function(name: "<%= contentDeliveryNetwork.functionNameSchema %>")
 <% } -%>
 }

--- a/provider-utils/awscloudformation/schemas/schema.graphql.ejs
+++ b/provider-utils/awscloudformation/schemas/schema.graphql.ejs
@@ -1,6 +1,6 @@
 
 
-type vodAsset @model (subscriptions: {level: public})
+type VodAsset @model (subscriptions: {level: public})
 @auth(
   rules: [
 <% if (locals.permissions && locals.permissions.permissionSchema.includes("any")) { -%>
@@ -21,11 +21,11 @@ type vodAsset @model (subscriptions: {level: public})
   description:String!
 
   #DO NOT EDIT
-  video:videoObject @connection
-} 
+  video:VideoObject @connection
+}
 
 #DO NOT EDIT
-type videoObject @model
+type VideoObject @model
 @auth(
   rules: [
 <% if (locals.permissions && locals.permissions.permissionSchema.includes("any")) { -%>

--- a/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/livestream-push.js
@@ -13,6 +13,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   const defaultLocation = path.resolve(`${__dirname}/../default-values/${defaultValuesFilename}`);
   let resource = {};
   const targetDir = amplify.pathManager.getBackendDirPath();
+  const projectDetails = context.amplify.getProjectDetails();
   let advancedAnswers = {};
   let mediaLiveAnswers = {};
   let mediaPackageAnswers;
@@ -22,7 +23,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
   defaults = JSON.parse(fs.readFileSync(`${defaultLocation}`));
   defaults.resourceName = 'mylivestream';
   try {
-    const oldValues = JSON.parse(fs.readFileSync(`${targetDir}/video/${resourceName}/props.json`));
+    const oldValues = JSON.parse(fs.readFileSync(`${targetDir}/video/${resourceName}/${projectDetails.localEnvInfo.envName}-props.json`));
     Object.assign(defaults, oldValues);
   } catch (err) {
     // Do nothing

--- a/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
@@ -50,7 +50,7 @@ async function serviceQuestions(context, options, defaultValuesFilename, resourc
     nameDict.resourceName = resourceName;
     props.shared = nameDict;
     try {
-      oldValues = JSON.parse(fs.readFileSync(`${targetDir}/video/${resourceName}/props.json`));
+      oldValues = JSON.parse(fs.readFileSync(`${targetDir}/video/${resourceName}/${projectDetails.localEnvInfo.envName}-props.json`));
       Object.assign(defaults, oldValues);
     } catch (err) {
       // Do nothing
@@ -307,7 +307,7 @@ async function createCDN(context, props, options, aws, oldValues) {
     const uuid = Math.random().toString(36).substring(2, 6)
                 + Math.random().toString(36).substring(2, 6);
     const secretName = `${props.shared.resourceName}-${projectDetails.localEnvInfo.envName}-pem-${uuid}`.slice(0, 63);
-    const rPublicName = `rCloudFrontPublicKey${uuid}`.slice(0, 63);
+    const rPublicName = `rCloudFrontPublicKey${projectDetails.localEnvInfo.envName}${uuid}`.slice(0, 63);
     const publicKeyName = `${props.shared.resourceName}-${projectDetails.localEnvInfo.envName}-publickey-${uuid}`.slice(0, 63);
     const smClient = new aws.SecretsManager({ apiVersion: '2017-10-17' });
     const createSecretParams = {

--- a/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
@@ -326,6 +326,7 @@ async function createCDN(context, props, options, aws, oldValues) {
     cdnConfigDetails.secretPemArn = secretCreate.ARN;
     cdnConfigDetails.functionName = (projectDetails.localEnvInfo.envName)
       ? `${props.shared.resourceName}-${projectDetails.localEnvInfo.envName}-tokenGen` : `${props.shared.resourceName}-tokenGen`;
+    cdnConfigDetails.functionNameSchema = `${props.shared.resourceName}-\${env}-tokenGen`;
   }
   return cdnConfigDetails;
 }

--- a/provider-utils/awscloudformation/utils/livestream-obs.js
+++ b/provider-utils/awscloudformation/utils/livestream-obs.js
@@ -19,6 +19,7 @@ async function setupOBS(context, resourceName) {
 async function createConfig(context, projectConfig, projectName) {
   // check for obs installation!
   let profileDir = '';
+  const projectDetails = context.amplify.getProjectDetails();
   if (process.platform === 'darwin') {
     profileDir = `${process.env.HOME}/Library/Application Support/obs-studio/basic/profiles/`;
   } else if (process.platform === 'win32') {
@@ -45,7 +46,7 @@ async function createConfig(context, projectConfig, projectName) {
     generateServiceLive(profileDir, projectConfig.output.oMediaLivePrimaryIngestUrl);
   } else if (projectConfig.serviceType === 'ivs') {
     const targetDir = context.amplify.pathManager.getBackendDirPath();
-    const props = JSON.parse(fs.readFileSync(`${targetDir}/video/${projectName}/props.json`));
+    const props = JSON.parse(fs.readFileSync(`${targetDir}/video/${projectName}/${projectDetails.localEnvInfo.envName}-props.json`));
     generateINIIVS(projectName, profileDir, props);
     generateServiceIVS(profileDir, projectConfig.output);
   }

--- a/provider-utils/awscloudformation/utils/video-staging.js
+++ b/provider-utils/awscloudformation/utils/video-staging.js
@@ -52,6 +52,54 @@ async function build(context, resourceName, projectType, props) {
   const { amplify } = context;
   const targetDir = amplify.pathManager.getBackendDirPath();
   const projectDetails = context.amplify.getProjectDetails();
+
+  const newEnvName = projectDetails.localEnvInfo.envName;
+  const resourceFilesBaseDir = `${targetDir}/video/${resourceName}/`;
+  const resourceFilesList = fs.readdirSync(resourceFilesBaseDir);
+
+
+  // Check if env-specific props file already exists
+  const hasOwnEnvProps = resourceFilesList.includes(`${newEnvName}-props.json`);
+
+  // Check if ANY props file exist for a different env in this project  || returns array
+  const hasAnyEnvProps = resourceFilesList.find(fileName => fileName.includes('-props.json'));
+
+  // If this env doesn't have its own props AND there is an existing amplify-video resource
+  if (!hasOwnEnvProps && hasAnyEnvProps) {
+    // take the first props file you find and copy that!
+    const propsFilenameToCopy = resourceFilesList.filter(propsFileName => propsFileName.includes('-props.json'))[0];
+
+    // extract substring for the existing env's name we're going to copy over
+    const envNameToReplace = propsFilenameToCopy.substr(0, propsFilenameToCopy.indexOf('-'));
+
+    // read JSON from the existing env's props file
+    const existingPropsToMutate = JSON.parse(fs.readFileSync(`${resourceFilesBaseDir}/${propsFilenameToCopy}`));
+
+    const searchAndReplaceProps = () => {
+      const newPropsObj = {};
+      // eslint-disable-next-line no-restricted-syntax
+      for (const [key, value] of Object.entries(existingPropsToMutate.contentDeliveryNetwork)) {
+        // look for any string values that contain existing env's name
+        if (typeof value === 'string' && value.includes(`${envNameToReplace}`)) {
+          // replace with new env name
+          const newValue = value.replace(new RegExp(envNameToReplace, 'g'), `${newEnvName}`);
+          newPropsObj[key] = newValue;
+        } else {
+          // copy existing values that do not match replacement conditions aka "generic props"
+          newPropsObj[key] = value;
+        }
+      }
+      return newPropsObj;
+    };
+
+    // merge new props and existing generic props
+    const newPropsToSave = Object.assign(
+      existingPropsToMutate, { contentDeliveryNetwork: searchAndReplaceProps() },
+    );
+
+    fs.writeFileSync(`${resourceFilesBaseDir}/${newEnvName}-props.json`, JSON.stringify(newPropsToSave, null, 4));
+  }
+
   if (!props) {
     props = JSON.parse(fs.readFileSync(`${targetDir}/video/${resourceName}/${projectDetails.localEnvInfo.envName}-props.json`));
   }

--- a/provider-utils/awscloudformation/utils/video-staging.js
+++ b/provider-utils/awscloudformation/utils/video-staging.js
@@ -51,8 +51,9 @@ async function pushTemplates(context) {
 async function build(context, resourceName, projectType, props) {
   const { amplify } = context;
   const targetDir = amplify.pathManager.getBackendDirPath();
+  const projectDetails = context.amplify.getProjectDetails();
   if (!props) {
-    props = JSON.parse(fs.readFileSync(`${targetDir}/video/${resourceName}/props.json`));
+    props = JSON.parse(fs.readFileSync(`${targetDir}/video/${resourceName}/${projectDetails.localEnvInfo.envName}-props.json`));
   }
   if (projectType === 'video-on-demand') {
     props = getVODEnvVars(context, props, resourceName);
@@ -95,7 +96,7 @@ function getVODEnvVars(context, props, resourceName) {
     delete props.shared.bucket;
     delete props.shared.bucketInput;
     delete props.shared.bucketOutput;
-    fs.writeFileSync(`${targetDir}/video/${resourceName}/props.json`, JSON.stringify(props, null, 4));
+    fs.writeFileSync(`${targetDir}/video/${resourceName}/${amplifyProjectDetails.localEnvInfo.envName}-props.json`, JSON.stringify(props, null, 4));
   }
   const envVars = amplifyProjectDetails.teamProviderInfo[currentEnvInfo]
     .categories.video[resourceName];

--- a/test.js
+++ b/test.js
@@ -1,0 +1,47 @@
+/* eslint-disable guard-for-in */
+/* eslint-disable no-restricted-syntax */
+const fs = require('fs');
+
+const newEnvName = 'tonia';
+const resourceDirectoryFiles = fs.readdirSync(
+  `${__dirname}/`,
+);
+
+// Check if env-specific props file already exists
+const hasOwnEnvProps = resourceDirectoryFiles.includes(`${newEnvName}-props.json`);
+
+// Check if ANY env props exist
+const hasAnyEnvProps = resourceDirectoryFiles.find(item => item.includes('-props.json'));
+
+// console.log('hasOwnEnv', hasOwnEnvProps);
+// console.log('hasAnyEnvProps', hasAnyEnvProps);
+
+if (!hasOwnEnvProps) {
+  if (hasAnyEnvProps) {
+    // take the first props file you find and copy that!
+    const propsFilenameToCopy = resourceDirectoryFiles.filter(propsFileName => propsFileName.includes('-props.json'))[0];
+    const envNameToReplace = propsFilenameToCopy.substr(0, propsFilenameToCopy.indexOf('-'));
+    const propsToMutate = JSON.parse(fs.readFileSync(`${__dirname}/${propsFilenameToCopy}`));
+
+    const searchAndReplaceProps = () => {
+      const newPropsObj = {};
+      for (const [key, value] of Object.entries(propsToMutate.contentDeliveryNetwork)) {
+        if (typeof value === 'string' && value.includes(`${envNameToReplace}`)) {
+          const newValue = value.replace(new RegExp(envNameToReplace, 'g'), `${newEnvName}`);
+          newPropsObj[key] = newValue;
+        } else {
+          newPropsObj[key] = value;
+        }
+      }
+      return newPropsObj;
+    };
+
+    const newPropsToSave = Object.assign(
+      propsToMutate, { contentDeliveryNetwork: searchAndReplaceProps() },
+    );
+
+    console.log('IM GONNA SAVE THIS, ', newPropsToSave);
+
+    fs.writeFileSync(`${__dirname}/${newEnvName}-props.json`, JSON.stringify(newPropsToSave, null, 4));
+  }
+}


### PR DESCRIPTION
### Related Issue
Closes https://github.com/awslabs/amplify-video/issues/249

### Related Conversation(s)
https://github.com/armenr/amplify-video/pull/1

### Description of changes

- Generate env-specific `props.json` as `${env}-props.json`
- Generate unique name for each public key (avoid name collision/resource already exists error)
- Enable multi-env support --> Successfully check out of/create multiple backend envs, each with its own set of amplify-video resources.  
- Capitalize generated GraphQL Models (VodAsset, VideoObject) for compliance with Admin-UI constraints (data modeling, etc.)

### Breaking changes

- Existing backend environments with already-deployed video resources require a user to run `amplify update video`
- Existing backends which already leverage signed URLS require `amplify update video` + `rotate keys` CLI flow

### Pending PR code that's in this branch
- added resource level tagging #205
- Added env to tokenGen #219
- Fix CloudFront Token Gen lambda #247

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.