### PR TITLE
Add extra params to rSnsInvokeLambdaSetup

### DIFF
--- a/provider-utils/awscloudformation/cloudformation-templates/vod-workflow-template.yaml.ejs
+++ b/provider-utils/awscloudformation/cloudformation-templates/vod-workflow-template.yaml.ejs
@@ -261,9 +261,14 @@ Resources:
     Properties:
       TemplateURL: !Sub "https://s3.amazonaws.com/${pS3}/${pSourceFolder}/SnsSetup.template"
       Parameters:
+        env: !Ref env
         pS3: !Ref pS3
         pSourceFolder: !Ref pSourceFolder
         pFunctionHash: "<%= props.hashes.MediaConvertStatusLambda %>"
+        <% if (props.parameters && props.parameters.GraphQLAPIId) { -%>
+        GraphQLAPIId: !Ref GraphQLAPIId
+        GraphQLEndpoint: !Ref GraphQLEndpoint
+        <% } -%>
         pFunctionName:
           !If
             - HasEnvironmentParameter


### PR DESCRIPTION
Add env, GraphQLAPIId & GraphQLEndpoint to rSnsInvokeLambdaSetup

*Issue #, if available:*
298
https://github.com/awslabs/amplify-video/issues/298

*Description of changes:*
Adds env, GraphQLAPIId & GraphQLEndpoint to rSnsInvokeLambdaSetup

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.