### PR TITLE
Headless get_info command for CICD

### DIFF
--- a/commands/video/get-info.js
+++ b/commands/video/get-info.js
@@ -23,7 +23,13 @@ module.exports = {
         default: Object.keys(amplifyMeta[category])[0],
       },
     ];
-    const props = await inquirer.prompt(chooseProject);
+    
+    let props;
+    if (context.parameters.options.default) {
+      props = {resourceName:chooseProject[0].default};
+    } else{
+      props = await inquirer.prompt(chooseProject);
+    }
 
     const options = amplifyMeta.video[props.resourceName];
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amplify-video/issues/300

*Description of changes:*
When using amplify CICD, the aws-video-exports file is not generated for the project.
However, a subsequent get_info call will generate the file.
This change allows this method to be called headless.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.