### PR TITLE
Fix AIM policy to allow Lambda function to execute

### DIFF
--- a/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/InputTriggerLambda.template
+++ b/provider-utils/awscloudformation/cloudformation-templates/vod-helpers/InputTriggerLambda.template
@@ -125,6 +125,7 @@ Resources:
                   - mediaconvert:ListJobs
                   - mediaconvert:ListQueues
                   - mediaconvert:ListPresets
+                  - mediaconvert:TagResource
                   - mediaconvert:UpdateJobTemplate
                 Resource:
                   - !Join ["", ["arn:aws:mediaconvert:", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":*"]]


### PR DESCRIPTION
*Issue #347:*
`AccessDeniedException` when invoking lambda function to convert video from input to output bucket

*Description of changes:*
Fix AIM policy that was raising the exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.